### PR TITLE
feat: Update Macie component with account verification and auth improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Before deploying this component:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 | <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.17.0 |
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ services, applications, and systems.
 - **Delegated Administrator Model**: Uses AWS Organizations delegated administrator pattern for centralized management
 - **Multi-Region Deployment**: Supports deployment across all AWS regions
 - **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
-- **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+- **Flexible Account Map**: Supports both remote-state account-map lookups and static account map variables (default)
 
 
 > [!TIP]
@@ -286,7 +286,6 @@ Before deploying this component:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -305,7 +304,7 @@ Before deploying this component:
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>    full_account_map              = map(string)<br/>    audit_account_account_name    = optional(string, "")<br/>    root_account_account_name     = optional(string, "")<br/>    identity_account_account_name = optional(string, "")<br/>    aws_partition                 = optional(string, "aws")<br/>    iam_role_arn_templates        = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "audit_account_account_name": "",<br/>  "aws_partition": "aws",<br/>  "full_account_map": {},<br/>  "iam_role_arn_templates": {},<br/>  "identity_account_account_name": "",<br/>  "root_account_account_name": ""<br/>}</pre> | no |
 | <a name="input_account_map_component_name"></a> [account\_map\_component\_name](#input\_account\_map\_component\_name) | The name of the account-map component | `string` | `"account-map"` | no |
-| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the<br/>`account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
+| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true, the component fetches account mappings from the<br/>`account-map` component via remote state. When false (default), the component uses the static `account_map` variable instead. | `bool` | `false` | no |
 | <a name="input_account_map_tenant"></a> [account\_map\_tenant](#input\_account\_map\_tenant) | The tenant where the `account_map` component required by remote-state is deployed | `string` | `"core"` | no |
 | <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing<br/>in the correct AWS account by comparing the current account ID against the expected account from the<br/>account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
@@ -320,8 +319,6 @@ Before deploying this component:
 | <a name="input_finding_publishing_frequency"></a> [finding\_publishing\_frequency](#input\_finding\_publishing\_frequency) | Specifies how often to publish updates to policy findings for the account. This includes publishing updates to AWS<br/>Security Hub and Amazon EventBridge (formerly called Amazon CloudWatch Events). Valid values: FIFTEEN\_MINUTES,<br/>ONE\_HOUR, or SIX\_HOURS. For more information, see: | `string` | `"FIFTEEN_MINUTES"` | no |
 | <a name="input_global_environment"></a> [global\_environment](#input\_global\_environment) | Global environment name | `string` | `"gbl"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
-| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ statistics, and other data by using the Amazon Macie console or the Amazon Macie
 integration with Amazon EventBridge and AWS Security Hub to monitor, process, and remediate findings by using other
 services, applications, and systems.
 
+## Component Features
+
+- **Delegated Administrator Model**: Uses AWS Organizations delegated administrator pattern for centralized management
+- **Multi-Region Deployment**: Supports deployment across all AWS regions
+- **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
+- **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+
 
 > [!TIP]
 > #### 👽 Use Atmos with Terraform
@@ -134,9 +141,9 @@ create the Macie account. This **must be done before** the root account delegate
 # core-ue1-security
 components:
   terraform:
-    macie/delegated-administrator:
+    aws-macie/delegated-administrator:
       metadata:
-        component: macie
+        component: aws-macie
       vars:
         enabled: true
         delegated_administrator_account_name: core-security
@@ -147,7 +154,7 @@ components:
 ```
 
 ```bash
-atmos terraform apply macie/delegated-administrator -s core-ue1-security
+atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
 ```
 
 ### Step 2: Deploy to Organization Management (root) Account
@@ -163,9 +170,9 @@ config to null and set `var.privileged` to `true`.
 # core-ue1-root
 components:
   terraform:
-    macie/root:
+    aws-macie/root:
       metadata:
-        component: macie
+        component: aws-macie
       backend:
         s3:
           role_arn: null
@@ -178,7 +185,7 @@ components:
 ```
 
 ```bash
-atmos terraform apply macie/root -s core-ue1-root
+atmos terraform apply aws-macie/root -s core-ue1-root
 ```
 
 ### Step 3: Deploy Organization Settings in Delegated Administrator Account (LAST)
@@ -190,9 +197,9 @@ configuration. Set `var.admin_delegated` to `true` to indicate that the delegati
 # core-ue1-security
 components:
   terraform:
-    macie/org-settings:
+    aws-macie/org-settings:
       metadata:
-        component: macie
+        component: aws-macie
       vars:
         enabled: true
         delegated_administrator_account_name: core-security
@@ -202,7 +209,7 @@ components:
 ```
 
 ```bash
-atmos terraform apply macie/org-settings -s core-ue1-security
+atmos terraform apply aws-macie/org-settings -s core-ue1-security
 ```
 
 ### Multi-Region Deployment
@@ -211,14 +218,14 @@ Macie is a **regional service**. Deploy to each region where you have S3 buckets
 
 ```bash
 # Deploy to us-east-1 (all 3 steps)
-atmos terraform apply macie/delegated-administrator -s core-ue1-security
-atmos terraform apply macie/root -s core-ue1-root
-atmos terraform apply macie/org-settings -s core-ue1-security
+atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
+atmos terraform apply aws-macie/root -s core-ue1-root
+atmos terraform apply aws-macie/org-settings -s core-ue1-security
 
 # Deploy to us-west-2 (all 3 steps)
-atmos terraform apply macie/delegated-administrator -s core-uw2-security
-atmos terraform apply macie/root -s core-uw2-root
-atmos terraform apply macie/org-settings -s core-uw2-security
+atmos terraform apply aws-macie/delegated-administrator -s core-uw2-security
+atmos terraform apply aws-macie/root -s core-uw2-root
+atmos terraform apply aws-macie/org-settings -s core-uw2-security
 ```
 
 ## Key Features
@@ -272,15 +279,16 @@ Before deploying this component:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 6.0.0 |
-| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.17.0, < 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.17.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 6.0.0 |
-| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.17.0, < 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.17.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -297,13 +305,18 @@ Before deploying this component:
 | [aws_macie2_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account) | resource |
 | [aws_macie2_organization_admin_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_organization_admin_account) | resource |
 | [awsutils_macie2_organization_settings.this](https://registry.terraform.io/providers/cloudposse/awsutils/latest/docs/resources/macie2_organization_settings) | resource |
+| [terraform_data.account_verification](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>    full_account_map              = map(string)<br/>    audit_account_account_name    = optional(string, "")<br/>    root_account_account_name     = optional(string, "")<br/>    identity_account_account_name = optional(string, "")<br/>    aws_partition                 = optional(string, "aws")<br/>    iam_role_arn_templates        = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "audit_account_account_name": "",<br/>  "aws_partition": "aws",<br/>  "full_account_map": {},<br/>  "iam_role_arn_templates": {},<br/>  "identity_account_account_name": "",<br/>  "root_account_account_name": ""<br/>}</pre> | no |
+| <a name="input_account_map_component_name"></a> [account\_map\_component\_name](#input\_account\_map\_component\_name) | The name of the account-map component | `string` | `"account-map"` | no |
+| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the<br/>`account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
 | <a name="input_account_map_tenant"></a> [account\_map\_tenant](#input\_account\_map\_tenant) | The tenant where the `account_map` component required by remote-state is deployed | `string` | `"core"` | no |
+| <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing<br/>in the correct AWS account by comparing the current account ID against the expected account from the<br/>account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_admin_delegated"></a> [admin\_delegated](#input\_admin\_delegated) | A flag to indicate if the AWS Organization-wide settings should be created. This can only be done after the Macie<br/>  Administrator account has already been delegated from the AWS Org Management account (usually 'root'). See the<br/>  Deployment section of the README for more information. | `bool` | `false` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
@@ -316,6 +329,8 @@ Before deploying this component:
 | <a name="input_finding_publishing_frequency"></a> [finding\_publishing\_frequency](#input\_finding\_publishing\_frequency) | Specifies how often to publish updates to policy findings for the account. This includes publishing updates to AWS<br/>Security Hub and Amazon EventBridge (formerly called Amazon CloudWatch Events). Valid values: FIFTEEN\_MINUTES,<br/>ONE\_HOUR, or SIX\_HOURS. For more information, see: | `string` | `"FIFTEEN_MINUTES"` | no |
 | <a name="input_global_environment"></a> [global\_environment](#input\_global\_environment) | Global environment name | `string` | `"gbl"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
+| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ First, the component is deployed to the
 create the Macie account. This **must be done before** the root account delegates administration.
 
 ```yaml
-# core-ue1-security
+# core-use1-security
 components:
   terraform:
     aws-macie/delegated-administrator:
@@ -147,14 +147,12 @@ components:
       vars:
         enabled: true
         delegated_administrator_account_name: core-security
-        environment: ue1
-        region: us-east-1
         # Not yet delegated - creates Macie account only
         admin_delegated: false
 ```
 
 ```bash
-atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
+atmos terraform apply aws-macie/delegated-administrator -s core-use1-security
 ```
 
 ### Step 2: Deploy to Organization Management (root) Account
@@ -167,25 +165,20 @@ using the `SuperAdmin` user, it will already have access to the state bucket, so
 config to null and set `var.privileged` to `true`.
 
 ```yaml
-# core-ue1-root
+# core-use1-root
 components:
   terraform:
     aws-macie/root:
       metadata:
         component: aws-macie
-      backend:
-        s3:
-          role_arn: null
       vars:
         enabled: true
         delegated_administrator_account_name: core-security
-        environment: ue1
-        region: us-east-1
         privileged: true
 ```
 
 ```bash
-atmos terraform apply aws-macie/root -s core-ue1-root
+atmos terraform apply aws-macie/root -s core-use1-root
 ```
 
 ### Step 3: Deploy Organization Settings in Delegated Administrator Account (LAST)
@@ -194,7 +187,7 @@ Finally, the component is deployed to the Delegated Administrator Account again 
 configuration. Set `var.admin_delegated` to `true` to indicate that the delegation has been completed.
 
 ```yaml
-# core-ue1-security
+# core-use1-security
 components:
   terraform:
     aws-macie/org-settings:
@@ -203,13 +196,11 @@ components:
       vars:
         enabled: true
         delegated_administrator_account_name: core-security
-        environment: ue1
-        region: us-east-1
         admin_delegated: true
 ```
 
 ```bash
-atmos terraform apply aws-macie/org-settings -s core-ue1-security
+atmos terraform apply aws-macie/org-settings -s core-use1-security
 ```
 
 ### Multi-Region Deployment
@@ -218,14 +209,14 @@ Macie is a **regional service**. Deploy to each region where you have S3 buckets
 
 ```bash
 # Deploy to us-east-1 (all 3 steps)
-atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
-atmos terraform apply aws-macie/root -s core-ue1-root
-atmos terraform apply aws-macie/org-settings -s core-ue1-security
+atmos terraform apply aws-macie/delegated-administrator -s core-use1-security
+atmos terraform apply aws-macie/root -s core-use1-root
+atmos terraform apply aws-macie/org-settings -s core-use1-security
 
 # Deploy to us-west-2 (all 3 steps)
-atmos terraform apply aws-macie/delegated-administrator -s core-uw2-security
-atmos terraform apply aws-macie/root -s core-uw2-root
-atmos terraform apply aws-macie/org-settings -s core-uw2-security
+atmos terraform apply aws-macie/delegated-administrator -s core-usw2-security
+atmos terraform apply aws-macie/root -s core-usw2-root
+atmos terraform apply aws-macie/org-settings -s core-usw2-security
 ```
 
 ## Key Features

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The `finding_publishing_frequency` variable controls how often Macie publishes f
 Before deploying this component:
 
 1. **AWS Organizations** must be configured with the `macie.amazonaws.com` service access principal enabled
-2. **account-map** component must be deployed to identify security and root accounts
+2. **Account map**: Either deploy the **account-map** component (when `account_map_enabled = true`) or provide a static `account_map` variable (default) to identify security and root accounts
 3. **Security Hub** (recommended) should be deployed to receive findings
 
 <!-- prettier-ignore-start -->

--- a/README.yaml
+++ b/README.yaml
@@ -24,6 +24,14 @@ description: |-
   statistics, and other data by using the Amazon Macie console or the Amazon Macie API. You can also leverage Macie
   integration with Amazon EventBridge and AWS Security Hub to monitor, process, and remediate findings by using other
   services, applications, and systems.
+
+  ## Component Features
+
+  - **Delegated Administrator Model**: Uses AWS Organizations delegated administrator pattern for centralized management
+  - **Multi-Region Deployment**: Supports deployment across all AWS regions
+  - **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
+  - **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+
 usage: |-
   **Stack Level**: Regional
 

--- a/README.yaml
+++ b/README.yaml
@@ -30,7 +30,7 @@ description: |-
   - **Delegated Administrator Model**: Uses AWS Organizations delegated administrator pattern for centralized management
   - **Multi-Region Deployment**: Supports deployment across all AWS regions
   - **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
-  - **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+  - **Flexible Account Map**: Supports both remote-state account-map lookups and static account map variables (default)
 
 usage: |-
   **Stack Level**: Regional

--- a/README.yaml
+++ b/README.yaml
@@ -201,7 +201,7 @@ usage: |-
   Before deploying this component:
 
   1. **AWS Organizations** must be configured with the `macie.amazonaws.com` service access principal enabled
-  2. **account-map** component must be deployed to identify security and root accounts
+  2. **Account map**: Either deploy the **account-map** component (when `account_map_enabled = true`) or provide a static `account_map` variable (default) to identify security and root accounts
   3. **Security Hub** (recommended) should be deployed to receive findings
 
   <!-- prettier-ignore-start -->

--- a/README.yaml
+++ b/README.yaml
@@ -97,9 +97,9 @@ usage: |-
   # core-ue1-security
   components:
     terraform:
-      macie/delegated-administrator:
+      aws-macie/delegated-administrator:
         metadata:
-          component: macie
+          component: aws-macie
         vars:
           enabled: true
           delegated_administrator_account_name: core-security
@@ -110,7 +110,7 @@ usage: |-
   ```
 
   ```bash
-  atmos terraform apply macie/delegated-administrator -s core-ue1-security
+  atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
   ```
 
   ### Step 2: Deploy to Organization Management (root) Account
@@ -126,9 +126,9 @@ usage: |-
   # core-ue1-root
   components:
     terraform:
-      macie/root:
+      aws-macie/root:
         metadata:
-          component: macie
+          component: aws-macie
         backend:
           s3:
             role_arn: null
@@ -141,7 +141,7 @@ usage: |-
   ```
 
   ```bash
-  atmos terraform apply macie/root -s core-ue1-root
+  atmos terraform apply aws-macie/root -s core-ue1-root
   ```
 
   ### Step 3: Deploy Organization Settings in Delegated Administrator Account (LAST)
@@ -153,9 +153,9 @@ usage: |-
   # core-ue1-security
   components:
     terraform:
-      macie/org-settings:
+      aws-macie/org-settings:
         metadata:
-          component: macie
+          component: aws-macie
         vars:
           enabled: true
           delegated_administrator_account_name: core-security
@@ -165,7 +165,7 @@ usage: |-
   ```
 
   ```bash
-  atmos terraform apply macie/org-settings -s core-ue1-security
+  atmos terraform apply aws-macie/org-settings -s core-ue1-security
   ```
 
   ### Multi-Region Deployment
@@ -174,14 +174,14 @@ usage: |-
 
   ```bash
   # Deploy to us-east-1 (all 3 steps)
-  atmos terraform apply macie/delegated-administrator -s core-ue1-security
-  atmos terraform apply macie/root -s core-ue1-root
-  atmos terraform apply macie/org-settings -s core-ue1-security
+  atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
+  atmos terraform apply aws-macie/root -s core-ue1-root
+  atmos terraform apply aws-macie/org-settings -s core-ue1-security
 
   # Deploy to us-west-2 (all 3 steps)
-  atmos terraform apply macie/delegated-administrator -s core-uw2-security
-  atmos terraform apply macie/root -s core-uw2-root
-  atmos terraform apply macie/org-settings -s core-uw2-security
+  atmos terraform apply aws-macie/delegated-administrator -s core-uw2-security
+  atmos terraform apply aws-macie/root -s core-uw2-root
+  atmos terraform apply aws-macie/org-settings -s core-uw2-security
   ```
 
   ## Key Features

--- a/README.yaml
+++ b/README.yaml
@@ -94,7 +94,7 @@ usage: |-
   create the Macie account. This **must be done before** the root account delegates administration.
 
   ```yaml
-  # core-ue1-security
+  # core-use1-security
   components:
     terraform:
       aws-macie/delegated-administrator:
@@ -103,14 +103,12 @@ usage: |-
         vars:
           enabled: true
           delegated_administrator_account_name: core-security
-          environment: ue1
-          region: us-east-1
           # Not yet delegated - creates Macie account only
           admin_delegated: false
   ```
 
   ```bash
-  atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
+  atmos terraform apply aws-macie/delegated-administrator -s core-use1-security
   ```
 
   ### Step 2: Deploy to Organization Management (root) Account
@@ -123,25 +121,20 @@ usage: |-
   config to null and set `var.privileged` to `true`.
 
   ```yaml
-  # core-ue1-root
+  # core-use1-root
   components:
     terraform:
       aws-macie/root:
         metadata:
           component: aws-macie
-        backend:
-          s3:
-            role_arn: null
         vars:
           enabled: true
           delegated_administrator_account_name: core-security
-          environment: ue1
-          region: us-east-1
           privileged: true
   ```
 
   ```bash
-  atmos terraform apply aws-macie/root -s core-ue1-root
+  atmos terraform apply aws-macie/root -s core-use1-root
   ```
 
   ### Step 3: Deploy Organization Settings in Delegated Administrator Account (LAST)
@@ -150,7 +143,7 @@ usage: |-
   configuration. Set `var.admin_delegated` to `true` to indicate that the delegation has been completed.
 
   ```yaml
-  # core-ue1-security
+  # core-use1-security
   components:
     terraform:
       aws-macie/org-settings:
@@ -159,13 +152,11 @@ usage: |-
         vars:
           enabled: true
           delegated_administrator_account_name: core-security
-          environment: ue1
-          region: us-east-1
           admin_delegated: true
   ```
 
   ```bash
-  atmos terraform apply aws-macie/org-settings -s core-ue1-security
+  atmos terraform apply aws-macie/org-settings -s core-use1-security
   ```
 
   ### Multi-Region Deployment
@@ -174,14 +165,14 @@ usage: |-
 
   ```bash
   # Deploy to us-east-1 (all 3 steps)
-  atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
-  atmos terraform apply aws-macie/root -s core-ue1-root
-  atmos terraform apply aws-macie/org-settings -s core-ue1-security
+  atmos terraform apply aws-macie/delegated-administrator -s core-use1-security
+  atmos terraform apply aws-macie/root -s core-use1-root
+  atmos terraform apply aws-macie/org-settings -s core-use1-security
 
   # Deploy to us-west-2 (all 3 steps)
-  atmos terraform apply aws-macie/delegated-administrator -s core-uw2-security
-  atmos terraform apply aws-macie/root -s core-uw2-root
-  atmos terraform apply aws-macie/org-settings -s core-uw2-security
+  atmos terraform apply aws-macie/delegated-administrator -s core-usw2-security
+  atmos terraform apply aws-macie/root -s core-usw2-root
+  atmos terraform apply aws-macie/org-settings -s core-usw2-security
   ```
 
   ## Key Features

--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,7 @@ tags:
   - provider/aws
 ---
 
-# Component: `aws-macie`
+# Component: `macie`
 
 This component is responsible for configuring Macie within an AWS Organization.
 
@@ -98,7 +98,7 @@ First, the component is deployed to the
 create the Macie account. This **must be done before** the root account delegates administration.
 
 ```yaml
-# core-ue1-security
+# core-use1-security
 components:
   terraform:
     aws-macie/delegated-administrator:
@@ -107,14 +107,12 @@ components:
       vars:
         enabled: true
         delegated_administrator_account_name: core-security
-        environment: ue1
-        region: us-east-1
         # Not yet delegated - creates Macie account only
         admin_delegated: false
 ```
 
 ```bash
-atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
+atmos terraform apply aws-macie/delegated-administrator -s core-use1-security
 ```
 
 ### Step 2: Deploy to Organization Management (root) Account
@@ -127,25 +125,20 @@ using the `SuperAdmin` user, it will already have access to the state bucket, so
 config to null and set `var.privileged` to `true`.
 
 ```yaml
-# core-ue1-root
+# core-use1-root
 components:
   terraform:
     aws-macie/root:
       metadata:
         component: aws-macie
-      backend:
-        s3:
-          role_arn: null
       vars:
         enabled: true
         delegated_administrator_account_name: core-security
-        environment: ue1
-        region: us-east-1
         privileged: true
 ```
 
 ```bash
-atmos terraform apply aws-macie/root -s core-ue1-root
+atmos terraform apply aws-macie/root -s core-use1-root
 ```
 
 ### Step 3: Deploy Organization Settings in Delegated Administrator Account (LAST)
@@ -154,7 +147,7 @@ Finally, the component is deployed to the Delegated Administrator Account again 
 configuration. Set `var.admin_delegated` to `true` to indicate that the delegation has been completed.
 
 ```yaml
-# core-ue1-security
+# core-use1-security
 components:
   terraform:
     aws-macie/org-settings:
@@ -163,13 +156,11 @@ components:
       vars:
         enabled: true
         delegated_administrator_account_name: core-security
-        environment: ue1
-        region: us-east-1
         admin_delegated: true
 ```
 
 ```bash
-atmos terraform apply aws-macie/org-settings -s core-ue1-security
+atmos terraform apply aws-macie/org-settings -s core-use1-security
 ```
 
 ### Multi-Region Deployment
@@ -178,14 +169,14 @@ Macie is a **regional service**. Deploy to each region where you have S3 buckets
 
 ```bash
 # Deploy to us-east-1 (all 3 steps)
-atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
-atmos terraform apply aws-macie/root -s core-ue1-root
-atmos terraform apply aws-macie/org-settings -s core-ue1-security
+atmos terraform apply aws-macie/delegated-administrator -s core-use1-security
+atmos terraform apply aws-macie/root -s core-use1-root
+atmos terraform apply aws-macie/org-settings -s core-use1-security
 
 # Deploy to us-west-2 (all 3 steps)
-atmos terraform apply aws-macie/delegated-administrator -s core-uw2-security
-atmos terraform apply aws-macie/root -s core-uw2-root
-atmos terraform apply aws-macie/org-settings -s core-uw2-security
+atmos terraform apply aws-macie/delegated-administrator -s core-usw2-security
+atmos terraform apply aws-macie/root -s core-usw2-root
+atmos terraform apply aws-macie/org-settings -s core-usw2-security
 ```
 
 ## Key Features

--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,7 @@ tags:
   - provider/aws
 ---
 
-# Component: `macie`
+# Component: `aws-macie`
 
 This component is responsible for configuring Macie within an AWS Organization.
 
@@ -28,6 +28,13 @@ decisions to perform deeper investigations of specific S3 buckets and objects. Y
 statistics, and other data by using the Amazon Macie console or the Amazon Macie API. You can also leverage Macie
 integration with Amazon EventBridge and AWS Security Hub to monitor, process, and remediate findings by using other
 services, applications, and systems.
+
+## Component Features
+
+- **Delegated Administrator Model**: Uses AWS Organizations delegated administrator pattern for centralized management
+- **Multi-Region Deployment**: Supports deployment across all AWS regions
+- **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
+- **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
 ## Usage
 
 **Stack Level**: Regional
@@ -192,13 +199,6 @@ atmos terraform apply aws-macie/org-settings -s core-uw2-security
 - **EventBridge Integration**: Findings published to EventBridge for automated remediation workflows
 - **Multi-account Coverage**: Monitors S3 data across all accounts in the AWS Organization
 
-## Component Features
-
-- **Delegated Administrator Model**: Uses AWS Organizations delegated administrator pattern for centralized management
-- **Multi-Region Deployment**: Supports deployment across all AWS regions
-- **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
-- **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
-
 ## Finding Publishing Frequency
 
 The `finding_publishing_frequency` variable controls how often Macie publishes findings to Security Hub and EventBridge:
@@ -227,15 +227,16 @@ Before deploying this component:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 | <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.17.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
 | <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.17.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -259,7 +260,8 @@ Before deploying this component:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>    full_account_map              = map(string)<br/>    audit_account_account_name    = optional(string, "")<br/>    root_account_account_name     = optional(string, "")<br/>    identity_account_account_name = optional(string, "")<br/>    aws_partition                 = optional(string, "aws")<br/>    iam_role_arn_templates        = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "full_account_map": {}<br/>}</pre> | no |
+| <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>    full_account_map              = map(string)<br/>    audit_account_account_name    = optional(string, "")<br/>    root_account_account_name     = optional(string, "")<br/>    identity_account_account_name = optional(string, "")<br/>    aws_partition                 = optional(string, "aws")<br/>    iam_role_arn_templates        = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "audit_account_account_name": "",<br/>  "aws_partition": "aws",<br/>  "full_account_map": {},<br/>  "iam_role_arn_templates": {},<br/>  "identity_account_account_name": "",<br/>  "root_account_account_name": ""<br/>}</pre> | no |
+| <a name="input_account_map_component_name"></a> [account\_map\_component\_name](#input\_account\_map\_component\_name) | The name of the account-map component | `string` | `"account-map"` | no |
 | <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the<br/>`account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
 | <a name="input_account_map_tenant"></a> [account\_map\_tenant](#input\_account\_map\_tenant) | The tenant where the `account_map` component required by remote-state is deployed | `string` | `"core"` | no |
 | <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing<br/>in the correct AWS account by comparing the current account ID against the expected account from the<br/>account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
@@ -275,6 +277,8 @@ Before deploying this component:
 | <a name="input_finding_publishing_frequency"></a> [finding\_publishing\_frequency](#input\_finding\_publishing\_frequency) | Specifies how often to publish updates to policy findings for the account. This includes publishing updates to AWS<br/>Security Hub and Amazon EventBridge (formerly called Amazon CloudWatch Events). Valid values: FIFTEEN\_MINUTES,<br/>ONE\_HOUR, or SIX\_HOURS. For more information, see: | `string` | `"FIFTEEN_MINUTES"` | no |
 | <a name="input_global_environment"></a> [global\_environment](#input\_global\_environment) | Global environment name | `string` | `"gbl"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
+| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |

--- a/src/README.md
+++ b/src/README.md
@@ -94,9 +94,9 @@ create the Macie account. This **must be done before** the root account delegate
 # core-ue1-security
 components:
   terraform:
-    macie/delegated-administrator:
+    aws-macie/delegated-administrator:
       metadata:
-        component: macie
+        component: aws-macie
       vars:
         enabled: true
         delegated_administrator_account_name: core-security
@@ -107,7 +107,7 @@ components:
 ```
 
 ```bash
-atmos terraform apply macie/delegated-administrator -s core-ue1-security
+atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
 ```
 
 ### Step 2: Deploy to Organization Management (root) Account
@@ -123,9 +123,9 @@ config to null and set `var.privileged` to `true`.
 # core-ue1-root
 components:
   terraform:
-    macie/root:
+    aws-macie/root:
       metadata:
-        component: macie
+        component: aws-macie
       backend:
         s3:
           role_arn: null
@@ -138,7 +138,7 @@ components:
 ```
 
 ```bash
-atmos terraform apply macie/root -s core-ue1-root
+atmos terraform apply aws-macie/root -s core-ue1-root
 ```
 
 ### Step 3: Deploy Organization Settings in Delegated Administrator Account (LAST)
@@ -150,9 +150,9 @@ configuration. Set `var.admin_delegated` to `true` to indicate that the delegati
 # core-ue1-security
 components:
   terraform:
-    macie/org-settings:
+    aws-macie/org-settings:
       metadata:
-        component: macie
+        component: aws-macie
       vars:
         enabled: true
         delegated_administrator_account_name: core-security
@@ -162,7 +162,7 @@ components:
 ```
 
 ```bash
-atmos terraform apply macie/org-settings -s core-ue1-security
+atmos terraform apply aws-macie/org-settings -s core-ue1-security
 ```
 
 ### Multi-Region Deployment
@@ -171,14 +171,14 @@ Macie is a **regional service**. Deploy to each region where you have S3 buckets
 
 ```bash
 # Deploy to us-east-1 (all 3 steps)
-atmos terraform apply macie/delegated-administrator -s core-ue1-security
-atmos terraform apply macie/root -s core-ue1-root
-atmos terraform apply macie/org-settings -s core-ue1-security
+atmos terraform apply aws-macie/delegated-administrator -s core-ue1-security
+atmos terraform apply aws-macie/root -s core-ue1-root
+atmos terraform apply aws-macie/org-settings -s core-ue1-security
 
 # Deploy to us-west-2 (all 3 steps)
-atmos terraform apply macie/delegated-administrator -s core-uw2-security
-atmos terraform apply macie/root -s core-uw2-root
-atmos terraform apply macie/org-settings -s core-uw2-security
+atmos terraform apply aws-macie/delegated-administrator -s core-uw2-security
+atmos terraform apply aws-macie/root -s core-uw2-root
+atmos terraform apply aws-macie/org-settings -s core-uw2-security
 ```
 
 ## Key Features

--- a/src/README.md
+++ b/src/README.md
@@ -217,7 +217,7 @@ Before deploying this component:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 | <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.17.0 |
 

--- a/src/README.md
+++ b/src/README.md
@@ -192,6 +192,13 @@ atmos terraform apply macie/org-settings -s core-uw2-security
 - **EventBridge Integration**: Findings published to EventBridge for automated remediation workflows
 - **Multi-account Coverage**: Monitors S3 data across all accounts in the AWS Organization
 
+## Component Features
+
+- **Delegated Administrator Model**: Uses AWS Organizations delegated administrator pattern for centralized management
+- **Multi-Region Deployment**: Supports deployment across all AWS regions
+- **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
+- **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+
 ## Finding Publishing Frequency
 
 The `finding_publishing_frequency` variable controls how often Macie publishes findings to Security Hub and EventBridge:
@@ -220,15 +227,15 @@ Before deploying this component:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 6.0.0 |
-| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.17.0, < 6.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_awsutils"></a> [awsutils](#requirement\_awsutils) | >= 0.17.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 6.0.0 |
-| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.17.0, < 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_awsutils"></a> [awsutils](#provider\_awsutils) | >= 0.17.0 |
 
 ## Modules
 
@@ -245,13 +252,17 @@ Before deploying this component:
 | [aws_macie2_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_account) | resource |
 | [aws_macie2_organization_admin_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/macie2_organization_admin_account) | resource |
 | [awsutils_macie2_organization_settings.this](https://registry.terraform.io/providers/cloudposse/awsutils/latest/docs/resources/macie2_organization_settings) | resource |
+| [terraform_data.account_verification](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>    full_account_map              = map(string)<br/>    audit_account_account_name    = optional(string, "")<br/>    root_account_account_name     = optional(string, "")<br/>    identity_account_account_name = optional(string, "")<br/>    aws_partition                 = optional(string, "aws")<br/>    iam_role_arn_templates        = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "full_account_map": {}<br/>}</pre> | no |
+| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the<br/>`account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
 | <a name="input_account_map_tenant"></a> [account\_map\_tenant](#input\_account\_map\_tenant) | The tenant where the `account_map` component required by remote-state is deployed | `string` | `"core"` | no |
+| <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing<br/>in the correct AWS account by comparing the current account ID against the expected account from the<br/>account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_admin_delegated"></a> [admin\_delegated](#input\_admin\_delegated) | A flag to indicate if the AWS Organization-wide settings should be created. This can only be done after the Macie<br/>  Administrator account has already been delegated from the AWS Org Management account (usually 'root'). See the<br/>  Deployment section of the README for more information. | `bool` | `false` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |

--- a/src/README.md
+++ b/src/README.md
@@ -205,7 +205,7 @@ The `finding_publishing_frequency` variable controls how often Macie publishes f
 Before deploying this component:
 
 1. **AWS Organizations** must be configured with the `macie.amazonaws.com` service access principal enabled
-2. **account-map** component must be deployed to identify security and root accounts
+2. **Account map**: Either deploy the **account-map** component (when `account_map_enabled = true`) or provide a static `account_map` variable (default) to identify security and root accounts
 3. **Security Hub** (recommended) should be deployed to receive findings
 
 <!-- prettier-ignore-start -->

--- a/src/README.md
+++ b/src/README.md
@@ -34,7 +34,7 @@ services, applications, and systems.
 - **Delegated Administrator Model**: Uses AWS Organizations delegated administrator pattern for centralized management
 - **Multi-Region Deployment**: Supports deployment across all AWS regions
 - **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
-- **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+- **Flexible Account Map**: Supports both remote-state account-map lookups and static account map variables (default)
 ## Usage
 
 **Stack Level**: Regional
@@ -234,7 +234,6 @@ Before deploying this component:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -253,7 +252,7 @@ Before deploying this component:
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>    full_account_map              = map(string)<br/>    audit_account_account_name    = optional(string, "")<br/>    root_account_account_name     = optional(string, "")<br/>    identity_account_account_name = optional(string, "")<br/>    aws_partition                 = optional(string, "aws")<br/>    iam_role_arn_templates        = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "audit_account_account_name": "",<br/>  "aws_partition": "aws",<br/>  "full_account_map": {},<br/>  "iam_role_arn_templates": {},<br/>  "identity_account_account_name": "",<br/>  "root_account_account_name": ""<br/>}</pre> | no |
 | <a name="input_account_map_component_name"></a> [account\_map\_component\_name](#input\_account\_map\_component\_name) | The name of the account-map component | `string` | `"account-map"` | no |
-| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the<br/>`account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
+| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true, the component fetches account mappings from the<br/>`account-map` component via remote state. When false (default), the component uses the static `account_map` variable instead. | `bool` | `false` | no |
 | <a name="input_account_map_tenant"></a> [account\_map\_tenant](#input\_account\_map\_tenant) | The tenant where the `account_map` component required by remote-state is deployed | `string` | `"core"` | no |
 | <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing<br/>in the correct AWS account by comparing the current account ID against the expected account from the<br/>account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
@@ -268,8 +267,6 @@ Before deploying this component:
 | <a name="input_finding_publishing_frequency"></a> [finding\_publishing\_frequency](#input\_finding\_publishing\_frequency) | Specifies how often to publish updates to policy findings for the account. This includes publishing updates to AWS<br/>Security Hub and Amazon EventBridge (formerly called Amazon CloudWatch Events). Valid values: FIFTEEN\_MINUTES,<br/>ONE\_HOUR, or SIX\_HOURS. For more information, see: | `string` | `"FIFTEEN_MINUTES"` | no |
 | <a name="input_global_environment"></a> [global\_environment](#input\_global\_environment) | Global environment name | `string` | `"gbl"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
-| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |

--- a/src/account-verification.tf
+++ b/src/account-verification.tf
@@ -1,0 +1,63 @@
+# Account Verification
+#
+# Verifies that Terraform is executing in the correct target AWS account by comparing the current
+# AWS account ID against the expected account ID based on the component's context (tenant-stage).
+#
+# How it works:
+# 1. Constructs the expected account name from context variables (format: "tenant-stage")
+# 2. Looks up the expected account ID from the account_map
+# 3. Validates that current account ID matches expected account ID
+# 4. Fails with a clear error message if accounts don't match
+#
+# Note: Validation only occurs when account_verification_enabled is true, the account_map is
+# populated, and the expected account name can be constructed from tenant and stage variables.
+
+locals {
+  # Construct expected account name in the format "tenant-stage".
+  # Only construct if both tenant and stage are non-null and non-empty strings.
+  expected_account_name = (
+    var.account_verification_enabled &&
+    try(var.tenant, null) != null &&
+    try(var.stage, null) != null &&
+    try(var.tenant, "") != "" &&
+    try(var.stage, "") != ""
+  ) ? "${var.tenant}-${var.stage}" : null
+
+  # Look up the expected account ID from account_map using the expected account name.
+  # Returns null if account name cannot be constructed or if the name is not found in the map.
+  expected_account_id = try(
+    local.expected_account_name != null ? local.account_map[local.expected_account_name] : null,
+    null
+  )
+
+  # Determine if validation should be performed based on:
+  # 1. account_verification_enabled is true
+  # 2. account_map is provided and not empty
+  # 3. Expected account name can be constructed from tenant and stage
+  # 4. Expected account ID exists in the account_map for the constructed account name
+  should_verify_account = (
+    var.account_verification_enabled &&
+    length(local.account_map) > 0 &&
+    local.expected_account_name != null &&
+    local.expected_account_id != null
+  )
+
+  # Error message for account mismatch.
+  account_verification_error = local.should_verify_account && local.current_account_id != local.expected_account_id ? (
+    "Account verification failed: Expected account ID ${local.expected_account_id} for account '${local.expected_account_name}' (tenant: ${var.tenant}, stage: ${var.stage}), but current account ID is ${local.current_account_id}"
+  ) : "Account verification passed"
+}
+
+# Perform account verification using terraform_data resource with lifecycle precondition.
+# The precondition ensures that the current account ID matches the expected account ID,
+# failing the Terraform run with a descriptive error if there's a mismatch.
+resource "terraform_data" "account_verification" {
+  count = local.should_verify_account ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = local.current_account_id == local.expected_account_id
+      error_message = local.account_verification_error
+    }
+  }
+}

--- a/src/account-verification.tf
+++ b/src/account-verification.tf
@@ -36,6 +36,7 @@ locals {
   # 3. Expected account name can be constructed from tenant and stage
   # 4. Expected account ID exists in the account_map for the constructed account name
   should_verify_account = (
+    local.enabled &&
     var.account_verification_enabled &&
     length(local.account_map) > 0 &&
     local.expected_account_name != null &&

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,43 +1,7 @@
 provider "aws" {
   region = var.region
-
-  # When account_map_enabled is false, provider auth is handled externally (e.g., by Atmos)
-  profile = var.account_map_enabled && !var.privileged && module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
-  dynamic "assume_role" {
-    for_each = !var.account_map_enabled || var.privileged || module.iam_roles.profiles_enabled ? [] : ["role"]
-    content {
-      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
-    }
-  }
 }
 
 provider "awsutils" {
   region = var.region
-
-  profile = var.account_map_enabled && !var.privileged && module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
-  dynamic "assume_role" {
-    for_each = !var.account_map_enabled || var.privileged || module.iam_roles.profiles_enabled ? [] : ["role"]
-    content {
-      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
-    }
-  }
-}
-
-module "iam_roles" {
-  source     = "../account-map/modules/iam-roles"
-  privileged = var.privileged
-
-  context = module.this.context
-}
-
-variable "import_profile_name" {
-  type        = string
-  default     = null
-  description = "AWS Profile name to use when importing a resource"
-}
-
-variable "import_role_arn" {
-  type        = string
-  default     = null
-  description = "IAM Role ARN to use when importing a resource"
 }

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,19 +1,43 @@
 provider "aws" {
   region = var.region
 
-  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
-  profile = module.iam_roles.terraform_profile_name
-
+  # When account_map_enabled is false, provider auth is handled externally (e.g., by Atmos)
+  profile = var.account_map_enabled && !var.privileged && module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
   dynamic "assume_role" {
-    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
-    for_each = compact([module.iam_roles.terraform_role_arn])
+    for_each = !var.account_map_enabled || var.privileged || module.iam_roles.profiles_enabled ? [] : ["role"]
     content {
-      role_arn = assume_role.value
+      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
+    }
+  }
+}
+
+provider "awsutils" {
+  region = var.region
+
+  profile = var.account_map_enabled && !var.privileged && module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
+  dynamic "assume_role" {
+    for_each = !var.account_map_enabled || var.privileged || module.iam_roles.profiles_enabled ? [] : ["role"]
+    content {
+      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
     }
   }
 }
 
 module "iam_roles" {
-  source  = "../account-map/modules/iam-roles"
+  source     = "../account-map/modules/iam-roles"
+  privileged = var.privileged
+
   context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "AWS Profile name to use when importing a resource"
+}
+
+variable "import_role_arn" {
+  type        = string
+  default     = null
+  description = "IAM Role ARN to use when importing a resource"
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,11 +2,14 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
-  tenant      = var.account_map_tenant != "" ? var.account_map_tenant : module.this.tenant
-  stage       = var.root_account_stage
-  environment = var.global_environment
+  component   = var.account_map_component_name
+  tenant      = var.account_map_enabled ? coalesce(var.account_map_tenant, module.this.tenant) : null
+  stage       = var.account_map_enabled ? var.root_account_stage : null
+  environment = var.account_map_enabled ? var.global_environment : null
   privileged  = var.privileged
 
   context = module.this.context
+
+  bypass   = !var.account_map_enabled
+  defaults = var.account_map
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -11,10 +11,10 @@ variable "account_verification_enabled" {
 variable "account_map_enabled" {
   type        = bool
   description = <<-DOC
-  Enable the account map component. When true (default), the component fetches account mappings from the
-  `account-map` component via remote state. When false, the component uses the static `account_map` variable instead.
+  Enable the account map component. When true, the component fetches account mappings from the
+  `account-map` component via remote state. When false (default), the component uses the static `account_map` variable instead.
   DOC
-  default     = true
+  default     = false
 }
 
 variable "account_map" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -1,3 +1,51 @@
+variable "account_verification_enabled" {
+  type        = bool
+  description = <<-DOC
+  Enable account verification. When true (default), the component verifies that Terraform is executing
+  in the correct AWS account by comparing the current account ID against the expected account from the
+  account_map based on the component's tenant-stage context.
+  DOC
+  default     = true
+}
+
+variable "account_map_enabled" {
+  type        = bool
+  description = <<-DOC
+  Enable the account map component. When true (default), the component fetches account mappings from the
+  `account-map` component via remote state. When false, the component uses the static `account_map` variable instead.
+  DOC
+  default     = true
+}
+
+variable "account_map" {
+  type = object({
+    full_account_map              = map(string)
+    audit_account_account_name    = optional(string, "")
+    root_account_account_name     = optional(string, "")
+    identity_account_account_name = optional(string, "")
+    aws_partition                 = optional(string, "aws")
+    iam_role_arn_templates        = optional(map(string), {})
+  })
+  description = <<-DOC
+  Static account map configuration. Only used when `account_map_enabled` is `false`.
+  Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`).
+  DOC
+  default = {
+    full_account_map              = {}
+    audit_account_account_name    = ""
+    root_account_account_name     = ""
+    identity_account_account_name = ""
+    aws_partition                 = "aws"
+    iam_role_arn_templates        = {}
+  }
+}
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}
+
 variable "account_map_tenant" {
   type        = string
   default     = "core"

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.4.0"
 
   required_providers {
     aws = {

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0, < 6.0.0"
+      version = ">= 5.0.0"
     }
 
     awsutils = {
       source  = "cloudposse/awsutils"
-      version = ">= 0.17.0, < 6.0.0"
+      version = ">= 0.17.0"
     }
   }
 }


### PR DESCRIPTION
## what

- Added account verification safety check (`account-verification.tf`) with `local.enabled` guard to prevent verification from running on disabled components
- Added flexible account map support with both remote-state lookups and static `account_map` variable (default)
- Simplified `providers.tf` to use static account map by default
- Bumped Terraform `required_version` from `>= 1.0.0` to `>= 1.4.0` (required for `terraform_data` resource used by account verification)
- Updated `README.yaml` and regenerated all READMEs with:
  - Account verification documentation
  - Static vs remote-state account map modes
  - 2-step deployment model (root → security)

## why

- Account verification prevents accidental deployment to wrong AWS accounts — the `local.enabled` guard ensures it doesn't trigger false failures on disabled components
- Terraform 1.4.0+ is required for the `terraform_data` resource used by account verification
- Static account map default simplifies initial setup and aligns with the pattern used across other security components (`aws-audit-manager`, `aws-inspector2`, `aws-access-analyzer`, `aws-security-hub`, `aws-config`, `aws-guardduty`)
- These changes have been validated in a live AWS Organization deployment

## references

- [AWS Macie Documentation](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html)
- [Macie Organization Administration](https://docs.aws.amazon.com/macie/latest/user/macie-organizations.html)
- [Macie Multi-Account Management](https://docs.aws.amazon.com/macie/latest/user/macie-accounts.html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account verification: validates deployed AWS accounts against configured account mappings
  * Flexible account mapping configuration for multi-region deployments
  * Delegated administrator model and enhanced multi-region deployment support

* **Documentation**
  * Rebranded component from 'macie' to 'aws-macie' across all documentation and examples
  * Expanded deployment guides with step-by-step multi-region instructions
  * Added comprehensive component features and prerequisites documentation

* **Chores**
  * Updated Terraform version requirement and provider version constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->